### PR TITLE
fix: cross browser behavior

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,6 @@
 import { defineConfig } from "astro/config";
 
-import tailwind from "@astrojs/tailwind";
-
 // https://astro.build/config
 export default defineConfig({
-  integrations: [tailwind()],
+  integrations: [],
 });

--- a/package.json
+++ b/package.json
@@ -12,10 +12,7 @@
   "devDependencies": {
     "@astrojs/tailwind": "^0.2.2",
     "astro": "^1.0.0-beta.63",
-    "autoprefixer": "^10.4.7",
-    "postcss": "^8.4.14",
     "prettier": "^2.7.1",
-    "prettier-plugin-astro": "0.0.12",
-    "tailwindcss": "^3.1.4"
+    "prettier-plugin-astro": "0.0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "prettify": "prettier -w ./src --plugin=./node_modules/prettier-plugin-astro"
   },
   "devDependencies": {
-    "@astrojs/tailwind": "^0.2.2",
     "astro": "^1.0.0-beta.63",
+    "autoprefixer": "^10.4.7",
+    "postcss": "^8.4.14",
     "prettier": "^2.7.1",
-    "prettier-plugin-astro": "0.0.12"
+    "prettier-plugin-astro": "0.0.12",
+    "tailwindcss": "^3.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,20 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@astrojs/tailwind': ^0.2.2
   astro: ^1.0.0-beta.63
+  autoprefixer: ^10.4.7
+  postcss: ^8.4.14
   prettier: ^2.7.1
   prettier-plugin-astro: 0.0.12
+  tailwindcss: ^3.1.5
 
 devDependencies:
-  '@astrojs/tailwind': 0.2.2
   astro: 1.0.0-beta.63
+  autoprefixer: 10.4.7_postcss@8.4.14
+  postcss: 8.4.14
   prettier: 2.7.1
   prettier-plugin-astro: 0.0.12
+  tailwindcss: 3.1.5
 
 packages:
 
@@ -112,17 +116,6 @@ packages:
       svelte2tsx: 0.5.11_wwvk7nlptlrqo2czohjtk6eiqm
     transitivePeerDependencies:
       - typescript
-    dev: true
-
-  /@astrojs/tailwind/0.2.2:
-    resolution: {integrity: sha512-0h32udM1+CNl0Jw1F/mwJJzhKWlYAAnrCTwk5+56aE6Q/cLNaJrSuxgArREtEGQoX2Fk+pJcbq4BPey0EP6VPA==}
-    dependencies:
-      '@proload/core': 0.3.2
-      autoprefixer: 10.4.7_postcss@8.4.14
-      postcss: 8.4.14
-      tailwindcss: 3.1.4
-    transitivePeerDependencies:
-      - ts-node
     dev: true
 
   /@astrojs/telemetry/0.2.3:
@@ -2877,6 +2870,23 @@ packages:
       yaml: 1.10.2
     dev: true
 
+  /postcss-load-config/4.0.1_postcss@8.4.14:
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.5
+      postcss: 8.4.14
+      yaml: 2.1.1
+    dev: true
+
   /postcss-nested/5.0.6_postcss@8.4.14:
     resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
     engines: {node: '>=12.0'}
@@ -3419,8 +3429,8 @@ packages:
       typescript: 4.6.4
     dev: true
 
-  /tailwindcss/3.1.4:
-    resolution: {integrity: sha512-NrxbFV4tYsga/hpWbRyUfIaBrNMXDxx5BsHgBS4v5tlyjf+sDsgBg5m9OxjrXIqAS/uR9kicxLKP+bEHI7BSeQ==}
+  /tailwindcss/3.1.5:
+    resolution: {integrity: sha512-bC/2dy3dGPqxMWAqFSRgQxVCfmO/31ZbeEp8s9DMDh4zgPZ5WW1gxRJkbBkXcTUIzaSUdhWrcsrSOe32ccgB4w==}
     engines: {node: '>=12.13.0'}
     hasBin: true
     dependencies:
@@ -3440,7 +3450,7 @@ packages:
       postcss: 8.4.14
       postcss-import: 14.1.0_postcss@8.4.14
       postcss-js: 4.0.0_postcss@8.4.14
-      postcss-load-config: 3.1.4_postcss@8.4.14
+      postcss-load-config: 4.0.1_postcss@8.4.14
       postcss-nested: 5.0.6_postcss@8.4.14
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
@@ -3851,6 +3861,11 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /yaml/2.1.1:
+    resolution: {integrity: sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==}
+    engines: {node: '>= 14'}
     dev: true
 
   /yargs-parser/21.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,20 +3,14 @@ lockfileVersion: 5.4
 specifiers:
   '@astrojs/tailwind': ^0.2.2
   astro: ^1.0.0-beta.63
-  autoprefixer: ^10.4.7
-  postcss: ^8.4.14
   prettier: ^2.7.1
   prettier-plugin-astro: 0.0.12
-  tailwindcss: ^3.1.4
 
 devDependencies:
   '@astrojs/tailwind': 0.2.2
   astro: 1.0.0-beta.63
-  autoprefixer: 10.4.7_postcss@8.4.14
-  postcss: 8.4.14
   prettier: 2.7.1
   prettier-plugin-astro: 0.0.12
-  tailwindcss: 3.1.4
 
 packages:
 

--- a/src/components/Clipboard.astro
+++ b/src/components/Clipboard.astro
@@ -4,7 +4,7 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
   aria-label="clipboard"
-  className="h-6 w-6"
+  class="h-6 w-6"
   fill="none"
   viewBox="0 0 24 24"
   stroke="currentColor"

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -5,7 +5,7 @@ const CURRENT_RECOMMENDED_COMMAND = "npx create-t3-app";
 
 <button id="copy-btn" class="relative group ml-8 pr-8 cursor-pointer">
   <div
-    class="absolute right-0 opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 transition-opacity flex items-center h-full"
+    class="absolute right-0 opacity-0 group-focus-within:opacity-100 group-hover-within:opacity-100 group-hover:opacity-100 group-focus:opacity-100 transition-opacity flex items-center h-full"
   >
     <ClipboardIcon />
   </div>
@@ -15,19 +15,16 @@ const CURRENT_RECOMMENDED_COMMAND = "npx create-t3-app";
     {CURRENT_RECOMMENDED_COMMAND}
   </code>
 </button>
-<div id="copy-success" class="mt-2 opacity-0">Copied Successfully!</div>
+<div id="copy-success" class="mt-2 opacity-0 duration-500 transition-opacity">Copied Successfully!</div>
 
 <script defer>
   const CURRENT_RECOMMENDED_COMMAND = "npx create-t3-app";
-  const copyBtn = document.querySelector("#copy-btn");
-  const copySuccess = document.querySelector("#copy-success");
+  const copyBtn = document.getElementById("copy-btn");
+  const copySuccess = document.getElementById("copy-success");
 
   copyBtn.addEventListener("click", () => {
     navigator.clipboard.writeText(CURRENT_RECOMMENDED_COMMAND);
-    copySuccess.classList.add(
-      "opacity-1",
-      "duration-500",
-      "transition-opacity"
-    );
+    copySuccess.classList.add("opacity-1"); // for safari
+    copySuccess.style.opacity = 1;  // for firefox/chrome
   });
 </script>


### PR DESCRIPTION
Closes #19 

Fixed the hover state on all three major browsers. Still can't get the Clipboard icon to show on Safari but I'll keep digging on this a bit more.

Click handler is now working on all three browsers. Had to do some wacky stuff cause it seems like Tailwind for astro has some weird behavior... e.g. setting the opacity style attribute to 1 worked on chrome and firefox but not on safari, and setting the class to opacity-1 worked on safari but not on firefox or chrome... interesting to say the least.

Seems like the CSS output is causing the hover-state of the clipboard icon on safari to bug out, manually changing it in devtools make it show but I'll see if I can't find a fix for this too.

Here is the behavior for now: https://share.cleanshot.com/vNYH8U