### PR TITLE
fix: add latest tag to create-t3-app command

### DIFF
--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -1,6 +1,6 @@
 ---
 import ClipboardIcon from "./Clipboard.astro";
-const CURRENT_RECOMMENDED_COMMAND = "npx create-t3-app";
+const CURRENT_RECOMMENDED_COMMAND = "npx create-t3-app@latest";
 ---
 
 <button id="copy-btn" class="relative group ml-8 pr-8 cursor-pointer">


### PR DESCRIPTION
This was done to keep it consistent with what is shown here: https://create.t3.gg/

<img width="459" alt="image" src="https://user-images.githubusercontent.com/8797405/183592967-638c9313-420a-4330-9462-44fdf20632a8.png">
